### PR TITLE
Enhance the `gotk_resource_info` metric

### DIFF
--- a/monitoring/configs/dashboards/cluster.json
+++ b/monitoring/configs/dashboards/cluster.json
@@ -32,7 +32,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -561,6 +561,8 @@
               "Value": true,
               "__name__": true,
               "app": true,
+              "chart_name": true,
+              "chart_source_name": true,
               "container": true,
               "customresource_group": true,
               "customresource_kind": false,
@@ -575,7 +577,9 @@
               "namespace": true,
               "pod": true,
               "pod_template_hash": true,
+              "revision": true,
               "service": true,
+              "source_name": true,
               "status": true,
               "type": true
             },
@@ -761,9 +765,11 @@
               "pod": true,
               "pod_template_hash": true,
               "ready": false,
+              "revision": true,
               "service": true,
               "status": true,
-              "type": true
+              "type": true,
+              "url": true
             },
             "indexByName": {
               "Time": 0,

--- a/monitoring/controllers/kube-prometheus-stack/release.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/release.yaml
@@ -27,7 +27,7 @@ spec:
           requests:
             cpu: 200m
             memory: 200Mi
-        podMonitorNamespaceSelector: {}
+        podMonitorNamespaceSelector: { }
         podMonitorSelector:
           matchLabels:
             app.kubernetes.io/component: monitoring
@@ -35,7 +35,7 @@ spec:
       defaultDashboardsEnabled: false
       adminPassword: flux
     kube-state-metrics:
-      collectors: []
+      collectors: [ ]
       extraArgs:
         - --custom-resource-state-only=true
       rbac:
@@ -44,8 +44,8 @@ spec:
               - source.toolkit.fluxcd.io
               - kustomize.toolkit.fluxcd.io
               - helm.toolkit.fluxcd.io
-              - image.toolkit.fluxcd.io
               - notification.toolkit.fluxcd.io
+              - image.toolkit.fluxcd.io
             resources:
               - gitrepositories
               - buckets
@@ -54,22 +54,60 @@ spec:
               - ocirepositories
               - kustomizations
               - helmreleases
-              - imagerepositories
-              - imagepolicies
-              - imageupdateautomations
               - alerts
               - providers
               - receivers
-            verbs: ["list", "watch"]
+              - imagerepositories
+              - imagepolicies
+              - imageupdateautomations
+            verbs: [ "list", "watch" ]
       customResourceState:
         enabled: true
         config:
           spec:
             resources:
-              - &metric
-                groupVersionKind:
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, lastAppliedRevision ]
+                      source_name: [ spec, sourceRef, name ]
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  version: v2beta1
+                  kind: HelmRelease
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, lastAppliedRevision ]
+                      chart_name: [ spec, chart, spec, chart ]
+                      chart_source_name: [ spec, chart, spec, sourceRef, name ]
+              - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: "v1"
+                  version: v1
                   kind: GitRepository
                 metricNamePrefix: gotk
                 metrics:
@@ -79,70 +117,197 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [metadata, name]
+                          name: [ metadata, name ]
                     labelsFromPath:
-                      exported_namespace: [metadata, namespace]
-                      ready: [status, conditions, "[type=Ready]", status]
-              - <<: *metric
-                groupVersionKind:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, artifact, revision ]
+                      url: [ spec, url ]
+              - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: "v1beta2"
+                  version: v1beta2
                   kind: Bucket
-              - <<: *metric
-                groupVersionKind:
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, artifact, revision ]
+                      endpoint: [ spec, endpoint ]
+                      bucket_name: [ spec, bucketName ]
+              - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: "v1beta2"
+                  version: v1beta2
                   kind: HelmRepository
-              - <<: *metric
-                groupVersionKind:
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, artifact, revision ]
+                      url: [ spec, url ]
+              - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: "v1beta2"
+                  version: v1beta2
                   kind: HelmChart
-              - <<: *metric
-                groupVersionKind:
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, artifact, revision ]
+                      chart_name: [ spec, chart ]
+                      chart_version: [ spec, version ]
+              - groupVersionKind:
                   group: source.toolkit.fluxcd.io
-                  version: "v1beta2"
+                  version: v1beta2
                   kind: OCIRepository
-              - <<: *metric
-                groupVersionKind:
-                  group: kustomize.toolkit.fluxcd.io
-                  version: "v1"
-                  kind: Kustomization
-              - <<: *metric
-                groupVersionKind:
-                  group: helm.toolkit.fluxcd.io
-                  version: "v2beta1"
-                  kind: HelmRelease
-              - <<: *metric
-                groupVersionKind:
-                  group: image.toolkit.fluxcd.io
-                  version: "v1beta2"
-                  kind: ImageRepository
-              - <<: *metric
-                groupVersionKind:
-                  group: image.toolkit.fluxcd.io
-                  version: "v1beta2"
-                  kind: ImagePolicy
-              - <<: *metric
-                groupVersionKind:
-                  group: image.toolkit.fluxcd.io
-                  version: "v1beta1"
-                  kind: ImageUpdateAutomation
-              - <<: *metric
-                groupVersionKind:
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      revision: [ status, artifact, revision ]
+                      url: [ spec, url ]
+              - groupVersionKind:
                   group: notification.toolkit.fluxcd.io
-                  version: "v1beta2"
+                  version: v1beta2
                   kind: Alert
-              - <<: *metric
-                groupVersionKind:
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+              - groupVersionKind:
                   group: notification.toolkit.fluxcd.io
-                  version: "v1beta2"
+                  version: v1beta2
                   kind: Provider
-              - <<: *metric
-                groupVersionKind:
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+              - groupVersionKind:
                   group: notification.toolkit.fluxcd.io
-                  version: "v1"
+                  version: v1
                   kind: Receiver
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      webhook_path: [ status, webhookPath ]
+              - groupVersionKind:
+                  group: image.toolkit.fluxcd.io
+                  version: v1beta2
+                  kind: ImageRepository
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      image: [ spec, image ]
+              - groupVersionKind:
+                  group: image.toolkit.fluxcd.io
+                  version: v1beta2
+                  kind: ImagePolicy
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      source_name: [ spec, imageRepositoryRef, name ]
+              - groupVersionKind:
+                  group: image.toolkit.fluxcd.io
+                  version: v1beta1
+                  kind: ImageUpdateAutomation
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a GitOps Toolkit resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+                    labelsFromPath:
+                      exported_namespace: [ metadata, namespace ]
+                      ready: [ status, conditions, "[type=Ready]", status ]
+                      suspended: [ spec, suspend ]
+                      source_name: [ spec, sourceRef, name ]
   postRenderers:
     - kustomize:
         patches:


### PR DESCRIPTION
This PR extends the `gotk_resource_info` metric with metadata specific to each GitOps Toolkit resource kind. 

### Changes

- Add `suspended` labels to all info metrics
- Add `url` and `revision` labels to GitRepository, OCIRepository, HelmRepository metrics
- Add `bucket_name`, `endpoint` and `revision` labels to Bucket metrics
- Add `chart_name`, `chart_version` and `revision` labels to HelmChart metrics
- Add `source_name` and `revision` labels to Kustomization objects
- Add `chart_source_name`, `chart_name` and `revision` labels to HelmRelease objects
- Add `webhook_path` labels to Receiver metrics
- Add `image` labels to ImageRepository metrics
- Add `source_name` labels to ImagePolicy metrics
- Update cluster dashboard to hide these new labels from the table panels.

⚠️ Given that `revision` can result in high cardinality metrics, we should instruct user how to remove this label if they don't have a use for it.

### Examples

Kustomization:

```go
gotk_resource_info{
    customresource_group="kustomize.toolkit.fluxcd.io",
    customresource_kind="Kustomization",
    customresource_version="v1", 
    exported_namespace="flux-system",
    name="monitoring-controllers", 
    source_name="monitoring",
    revision="metrics@sha1:63f64aa7109ed7cd6ff76be3dc0d0a1580a38c9b",
    ready="True"
}
```

GitRepositry:

```go
gotk_resource_info{
    customresource_group="source.toolkit.fluxcd.io",
    customresource_kind="GitRepository",
    customresource_version="v1", 
    exported_namespace="flux-system", 
    name="monitoring",
    revision="metrics@sha1:e8f85cc9ac1a17f6224d3046d4f714e8ff8b539c",
    url="https://github.com/fluxcd/flux2-monitoring-example.git",
    ready="True"
}
```

HelmRelease:

```go
gotk_resource_info{
    customresource_group="helm.toolkit.fluxcd.io",
    customresource_kind="HelmRelease",
    customresource_version="v2beta1",
    exported_namespace="monitoring", 
    name="loki-stack", 
    chart_source_name="grafana-charts",
    chart_name="loki-stack",
    revision="2.9.11",
    ready="True"
}
```

HelmChart:

```go
gotk_resource_info{
    customresource_group="source.toolkit.fluxcd.io",
    customresource_kind="HelmChart",
    customresource_version="v1beta2",
    exported_namespace="monitoring",
    name="monitoring-loki-stack",
    chart_name="loki-stack",
    chart_version="2.x",
    revision="2.9.11",
    ready="True"
}
```

HelmRepository:

```go
gotk_resource_info{
    customresource_group="source.toolkit.fluxcd.io",
    customresource_kind="HelmRepository",
    customresource_version="v1beta2",
    exported_namespace="monitoring",
    name="grafana-charts",
    revision="sha256:c10ae0b0798a616b1aa494128294f223e5c36047e35508fbab57d0a30f0a834f",
    url="https://grafana.github.io/helm-charts",
    ready="True"
}
```
