### PR TITLE
cluster dashboard: exclude `bucket_name` in sources

### DIFF
--- a/monitoring/configs/dashboards/cluster.json
+++ b/monitoring/configs/dashboards/cluster.json
@@ -750,6 +750,7 @@
               "Value": true,
               "__name__": true,
               "app": true,
+              "bucket_name": true,
               "container": true,
               "customresource_group": true,
               "customresource_kind": false,


### PR DESCRIPTION
Add `bucket_name` to the list of excluded fields in the transformation for source readiness.
This is needed to not introduce a new field in the source acquisition readiness panel when a Bucket resource is present.