### PR TITLE
cluster dashboard: exclude `suspended` in readiness

### DIFF
--- a/monitoring/configs/dashboards/cluster.json
+++ b/monitoring/configs/dashboards/cluster.json
@@ -581,6 +581,7 @@
               "service": true,
               "source_name": true,
               "status": true,
+              "suspended": true,
               "type": true
             },
             "indexByName": {
@@ -769,6 +770,7 @@
               "revision": true,
               "service": true,
               "status": true,
+              "suspended": true,
               "type": true,
               "url": true
             },


### PR DESCRIPTION
Add `suspended` to the list of excluded fields in the transformation for resource readiness. This is needed to not introduce a new field in cluster reconciliation readiness and source acquisition readiness panels when a resource is suspended.