### PR TITLE
KSM config: Update for NC v1beta3 API

### DIFF
--- a/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
@@ -168,7 +168,7 @@ kube-state-metrics:
                   url: [ spec, url ]
           - groupVersionKind:
               group: notification.toolkit.fluxcd.io
-              version: v1beta2
+              version: v1beta3
               kind: Alert
             metricNamePrefix: gotk
             metrics:
@@ -181,11 +181,10 @@ kube-state-metrics:
                       name: [ metadata, name ]
                 labelsFromPath:
                   exported_namespace: [ metadata, namespace ]
-                  ready: [ status, conditions, "[type=Ready]", status ]
                   suspended: [ spec, suspend ]
           - groupVersionKind:
               group: notification.toolkit.fluxcd.io
-              version: v1beta2
+              version: v1beta3
               kind: Provider
             metricNamePrefix: gotk
             metrics:
@@ -198,7 +197,6 @@ kube-state-metrics:
                       name: [ metadata, name ]
                 labelsFromPath:
                   exported_namespace: [ metadata, namespace ]
-                  ready: [ status, conditions, "[type=Ready]", status ]
                   suspended: [ spec, suspend ]
           - groupVersionKind:
               group: notification.toolkit.fluxcd.io


### PR DESCRIPTION
Depends on https://github.com/fluxcd/notification-controller/pull/540.

The alert and provider APIs from notification-controller no longer have status to report readiness.
Dashboards should be designed to assume Ready=True for no status. The Flux Cluster Stats dashboard already does this for the objects it shows.

**NOTE:** Similar change is not needed for HelmRepository OCI, which is also losing status in https://github.com/fluxcd/source-controller/pull/1243, because the status is needed for the default type HelmRepository. The Flux Cluster Stats dashboard will show HelmRepository OCI objects as Ready always.