### PR TITLE
Fix installation on talos.dev

### DIFF
--- a/monitoring/controllers/kube-prometheus-stack/namespace.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: monitoring
   labels:
     app.kubernetes.io/component: monitoring
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
When installing on talos.dev the prometheus is not running.
The issue is using of PodSecurityConfiguration
There some labels must be present on NS monitoring
I fixed it
I am kindly asking to accept this PR.