### PR TITLE
PodMonitor: remove now unneeded relabel config

### DIFF
--- a/monitoring/configs/podmonitor.yaml
+++ b/monitoring/configs/podmonitor.yaml
@@ -22,8 +22,3 @@ spec:
           - image-reflector-controller
   podMetricsEndpoints:
     - port: http-prom
-      relabelings:
-        # https://github.com/prometheus-operator/prometheus-operator/issues/4816
-        - sourceLabels: [__meta_kubernetes_pod_phase]
-          action: keep
-          regex: Running


### PR DESCRIPTION
Ever since
https://github.com/prometheus-operator/prometheus-operator/pull/5049,
the relabel config workaround to ignore non-running pods is no longer
needed. This commit cleans up the podmonitor to keep the code tidy.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Fix: #37
