### PR TITLE
Update ImageUpdateAutomation API to v1beta2

### DIFF
--- a/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
@@ -257,7 +257,7 @@ kube-state-metrics:
                   source_name: [ spec, imageRepositoryRef, name ]
           - groupVersionKind:
               group: image.toolkit.fluxcd.io
-              version: v1beta1
+              version: v1beta2
               kind: ImageUpdateAutomation
             metricNamePrefix: gotk
             metrics:


### PR DESCRIPTION
Depends on https://github.com/fluxcd/image-automation-controller/pull/647, and should be merged after ImageUpdateAutomation API v1beta2 is officially released as part of the next flux release.