### PR TITLE
Update `kube-prometheus-stack` to v58 and make the `gotk_resource_info` help text unique

### DIFF
--- a/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
@@ -40,7 +40,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux Kustomization resource."
                 each:
                   type: Info
                   info:
@@ -59,7 +59,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux HelmRelease resource."
                 each:
                   type: Info
                   info:
@@ -79,7 +79,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux GitRepository resource."
                 each:
                   type: Info
                   info:
@@ -98,7 +98,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux Bucket resource."
                 each:
                   type: Info
                   info:
@@ -118,7 +118,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux HelmRepository resource."
                 each:
                   type: Info
                   info:
@@ -137,7 +137,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux HelmChart resource."
                 each:
                   type: Info
                   info:
@@ -157,7 +157,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux OCIRepository resource."
                 each:
                   type: Info
                   info:
@@ -176,7 +176,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux Alert resource."
                 each:
                   type: Info
                   info:
@@ -192,7 +192,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux Provider resource."
                 each:
                   type: Info
                   info:
@@ -208,7 +208,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux Receiver resource."
                 each:
                   type: Info
                   info:
@@ -226,7 +226,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux ImageRepository resource."
                 each:
                   type: Info
                   info:
@@ -244,7 +244,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux ImagePolicy resource."
                 each:
                   type: Info
                   info:
@@ -262,7 +262,7 @@ kube-state-metrics:
             metricNamePrefix: gotk
             metrics:
               - name: "resource_info"
-                help: "The current state of a GitOps Toolkit resource."
+                help: "The current state of a Flux ImageUpdateAutomation resource."
                 each:
                   type: Info
                   info:

--- a/monitoring/controllers/kube-prometheus-stack/release.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/release.yaml
@@ -6,7 +6,7 @@ spec:
   interval: 1h
   chart:
     spec:
-      version: "55.x"
+      version: "58.x"
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Make the help texts unique in kube-state-metrics `customResourceState` config to workaround the bug in the latest kube-state-metrics version https://github.com/kubernetes/kube-state-metrics/issues/2366#issuecomment-2058901252

Fixes #32