### PR TITLE
Add missing Grafana Dashboard debug log level filter

### DIFF
--- a/monitoring/configs/dashboards/logs.json
+++ b/monitoring/configs/dashboards/logs.json
@@ -197,7 +197,7 @@
         "type": "textbox"
       },
       {
-        "allValue": "info|error",
+        "allValue": "debug|info|error",
         "current": {
           "selected": false,
           "text": "All",
@@ -215,6 +215,11 @@
           },
           {
             "selected": false,
+            "text": "debug",
+            "value": "debug"
+          },
+          {
+            "selected": false,
             "text": "info",
             "value": "info"
           },
@@ -224,7 +229,7 @@
             "value": "error"
           }
         ],
-        "query": "info,error",
+        "query": "debug,info,error",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"


### PR DESCRIPTION
![Screenshot 2024-06-24 at 10 19 54](https://github.com/fluxcd/flux2-monitoring-example/assets/4599319/f82850cd-bd22-43ae-97dd-1f429c42c96d)

For me, logs were missing in the dashboard because I could not filter them.

Using Flux 2.2.3