### PR TITLE
Fix Loki to work with Flux grafana/prometheus examples again

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Flux
         uses: fluxcd/flux2/action@main
       - name: Setup Kubernetes

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flux
         uses: fluxcd/flux2/action@main
       - name: Setup Kubernetes
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.12.0
         with:
           cluster_name: flux
           version: v0.20.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup yq
         uses: fluxcd/pkg/actions/yq@main
       - name: Setup kubeconform

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is an example of how to make use of
 [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 and
-[loki-stack](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack)
+[loki](https://github.com/grafana/loki/tree/main/production/helm/loki)
 to monitor Flux.
 
 Components:
@@ -72,13 +72,15 @@ After Flux has finished reconciling, you can list the pods in the monitoring nam
 ```console
 $ kubectl -n monitoring get po
 NAME                                                        READY
-kube-prometheus-stack-grafana-5c976ff4cf-xgmwm              3/3
-kube-prometheus-stack-kube-state-metrics-5dcf4c4697-jvlvh   1/1
-kube-prometheus-stack-operator-75f9fdcbf6-98zmh             1/1
-kube-prometheus-stack-prometheus-node-exporter-j4vhb        1/1
-loki-stack-0                                                1/1
-loki-stack-promtail-dcg64                                   1/1
+kube-prometheus-stack-grafana-58977b8976-8557b              3/3
+kube-prometheus-stack-kube-state-metrics-676657b78f-8w9pd   1/1
+kube-prometheus-stack-operator-7467d457b7-4qzks             1/1
+kube-prometheus-stack-prometheus-node-exporter-wcwds        1/1
+loki-0                                                      2/2
+loki-gateway-5669d46565-ldv9f                               1/1
+loki-minio-0                                                1/1
 prometheus-kube-prometheus-stack-prometheus-0               2/2
+promtail-tg5f8                                              1/1
 ```
 
 ### Accessing Grafana

--- a/monitoring/controllers/kube-prometheus-stack/repository.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/repository.yaml
@@ -6,7 +6,7 @@ spec:
   interval: 1h
   url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
   ref:
-    semver: "58.x"
+    semver: "69.x"
   layerSelector:
     mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
     operation: copy

--- a/monitoring/controllers/loki-stack/kustomization.yaml
+++ b/monitoring/controllers/loki-stack/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: monitoring
 resources:
   - repository.yaml
   - release.yaml
+  - promtail-release.yaml

--- a/monitoring/controllers/loki-stack/promtail-release.yaml
+++ b/monitoring/controllers/loki-stack/promtail-release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: promtail
+spec:
+  interval: 5m
+  timeout: 1m
+  dependsOn:
+    - name: kube-prometheus-stack
+  chart:
+    spec:
+      version: "6.x"
+      chart: promtail
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+      interval: 60m
+  values:
+    # https://grafana.com/docs/loki/latest/send-data/promtail/installation/
+    config:
+    # publish data to loki
+      clients:
+        - url: http://loki-gateway/loki/api/v1/push
+          tenant_id: 1

--- a/monitoring/controllers/loki-stack/release.yaml
+++ b/monitoring/controllers/loki-stack/release.yaml
@@ -1,34 +1,103 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: loki-stack
+  name: loki
 spec:
   interval: 5m
   dependsOn:
     - name: kube-prometheus-stack
   chart:
     spec:
-      version: "2.x"
-      chart: loki-stack
+      version: "6.x"
+      chart: loki
       sourceRef:
         kind: HelmRepository
         name: grafana-charts
       interval: 60m
-  # https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/values.yaml
-  # https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
   values:
-    promtail:
-      enabled: true
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    test:
+      enabled: false
+    # following https://github.com/fluxcd/flux2-monitoring-example/pull/23/files#diff-5e041afacf25eb055565b4a1c32d5b81201ddce29c84adf13a6ae88463e0832b
+    extraObjects:
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: loki-datasource
+          labels:
+            app: loki
+            chart: loki
+            release: loki
+            grafana_datasource: "1"
+            app.kubernetes.io/part-of: kube-prometheus-stack
+        data:
+          loki-datasource.yaml: |-
+            apiVersion: 1
+            datasources:
+            - name: Loki
+              type: loki
+              access: proxy
+              url: http://loki:{{ .Values.loki.server.http_listen_port }}
+              version: 1
+              isDefault: false
     loki:
-      enabled: true
-      isDefault: false
+      auth_enabled: false
       serviceMonitor:
         enabled: true
-        additionalLabels:
+        labels:
           app.kubernetes.io/part-of: kube-prometheus-stack
-      config:
-        chunk_store_config:
-          max_look_back_period: 0s
-        table_manager:
-          retention_deletes_enabled: true
-          retention_period: 12h
+      limits_config:
+        allow_structured_metadata: true
+        retention_period: 24h
+        volume_enabled: true
+      # https://grafana.com/docs/loki/latest/setup/install/helm/install-monolithic/
+      commonConfig:
+        replication_factor: 1
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: s3
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+      pattern_ingester:
+        enabled: true
+      ruler:
+        enable_api: true
+    minio:
+      enabled: true
+    lokiCanary:
+      enabled: false
+    deploymentMode: SingleBinary
+    singleBinary:
+      replicas: 1
+    # Zero out replica counts of other deployment modes
+    backend:
+      replicas: 0
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    ingester:
+      replicas: 0
+    querier:
+      replicas: 0
+    queryFrontend:
+      replicas: 0
+    queryScheduler:
+      replicas: 0
+    distributor:
+      replicas: 0
+    compactor:
+      replicas: 0
+    indexGateway:
+      replicas: 0
+    bloomCompactor:
+      replicas: 0
+    bloomGateway:
+      replicas: 0


### PR DESCRIPTION
Fix #19, Close #23

I got this working locally, running on Kind

In the grafana dashboard, there is a loki data source configured with address `loki-stack:3100`

I was unable to find this string in the kube-prometheus-stack chart, so I'm guessing it has been inferred somehow by Grafana's chart? The old `loki-stack` chart that provided promtail is obsolete.

I updated this to use `loki` chart instead, that is maintained, there is an OCI chart but it isn't kept up-to-date (the tag is labeled "weekly" but is several months out-of-date, and the latest release is in the legacy helm repository for grafana charts)

The `loki` chart is kept current. There's a `promtail` chart in the grafana helm charts repo as well.

I disabled authentication, because I believe that's how kube-prometheus-stack did it. In no way is this a sensible Loki configuration, but it works in kind for demonstrative purposes. I will personally be disabling loki on my clusters, not because this is too hard, but because we're using cloudtrail for logs (which I think has Grafana integration too)

Anyway, we can't demo cloudtrail in a kind cluster so this is better.

It still needs some documentation updates, the README for example shows the loki and promtail pods deployed from loki-stack chart, but mine looks a bit more like this now:

```
monitoring           kube-prometheus-stack-grafana-58977b8976-vw65n              3/3     Running   0          78m
monitoring           kube-prometheus-stack-kube-state-metrics-676657b78f-sfknq   1/1     Running   0          78m
monitoring           kube-prometheus-stack-operator-7467d457b7-x2jwc             1/1     Running   0          78m
monitoring           kube-prometheus-stack-prometheus-node-exporter-cq2nn        1/1     Running   0          78m
monitoring           loki-canary-w6c8r                                           1/1     Running   0          21m
monitoring           loki-stack-0                                                2/2     Running   0          21m
monitoring           loki-stack-gateway-589dcdd94f-qljpd                         1/1     Running   0          23m
monitoring           loki-stack-minio-0                                          1/1     Running   0          23m
monitoring           prometheus-kube-prometheus-stack-prometheus-0               2/2     Running   0          77m
monitoring           promtail-m4snt                                              1/1     Running   0          10m
```

I also disabled the two redis instances that loki installs in the default monolithic version, and verified that I can see some logs in the "Flux Logs" dashboard. I am not certain about this config but I will come back and review it ASAP so we can close out long-standing issues like #19 and hopefully avoid removing Loki from the example.

Some of these logs do not look like they are from Flux:

<img width="1436" alt="Screenshot 2025-02-12 at 12 44 20 PM" src="https://github.com/user-attachments/assets/68c7b488-95f8-4a29-95af-67b3b872a0cb" />

I have a feeling if I look more closely at the config for promtail that I discarded, I'll find that it was meant to select the flux pods somehow. Unsure. I can't spend more time on this right now, but will try to come back with another try before the dev meeting next week. (At a minimum I'll clean up the bootstrap artifacts and other noise from this PR so we can merge it.)