### PR TITLE
Updating Bucket version from v1beta2 to v1

### DIFF
--- a/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
@@ -95,7 +95,7 @@ kube-state-metrics:
                   url: [ spec, url ]
           - groupVersionKind:
               group: source.toolkit.fluxcd.io
-              version: v1beta2
+              version: v1
               kind: Bucket
             metricNamePrefix: gotk
             metrics:


### PR DESCRIPTION
I have checked api-resources on the relevant flux version (2.5.0) and it does not have Bucket/v1beta2 anymore. kube-state-metrics pod contains an advice in logs to update this version here.