### PR TITLE
Fix e2e timing out

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,7 +36,7 @@ jobs:
           --path=./clusters/test
       - name: Verify cluster reconciliation
         run: |
-          kubectl -n flux-system wait kustomization/monitoring-controllers --for=condition=ready --timeout=10m
+          kubectl -n flux-system wait kustomization/monitoring-controllers --for=condition=ready --timeout=20m
           kubectl -n flux-system wait kustomization/monitoring-configs --for=condition=ready --timeout=1m
       - name: Debug failure
         if: failure()


### PR DESCRIPTION
After the last merge the e2e started timing out ([link](https://github.com/fluxcd/flux2-monitoring-example/actions/workflows/e2e.yaml)), and it's not due to any problems in the configuration. I ran the cluster locally and it really just takes a while for the sync to finish, so I'm increasing the timeout.