### PR TITLE
Easier identification of long reconciliation durations

### DIFF
--- a/monitoring/configs/dashboards/cluster.json
+++ b/monitoring/configs/dashboards/cluster.json
@@ -1111,7 +1111,7 @@
         },
         "tooltip": {
           "mode": "multi",
-          "sort": "none"
+          "sort": "desc"
         }
       },
       "pluginVersion": "10.0.3",
@@ -1243,7 +1243,7 @@
         },
         "tooltip": {
           "mode": "multi",
-          "sort": "none"
+          "sort": "desc"
         }
       },
       "pluginVersion": "10.0.3",


### PR DESCRIPTION
Just a simple improvement that forces the sorting of the hover tooltip for the duration panels.

This makes it much simpler to quickly identify which object has the longest reconciliation without having to look through the whole list searching for the highlighted item.

<img width="764" alt="image" src="https://github.com/user-attachments/assets/cd2068d9-52a4-4672-ae51-bb8c523a938c" />
