### PR TITLE
Updated README.md with flux cli commands to bootsrap monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,48 @@ flux bootstrap github \
     --path=clusters/test
 ```
 
+### Induvidually install monitoring components
+
+Register flux git registry
+```shell
+flux create source git flux-monitoring \
+  --interval=30m \
+  --url=https://github.com/fluxcd/flux2-monitoring-example \
+  --branch=main
+```
+
+Deploy cofiguration kustomization
+```shell
+flux create kustomization config \
+  --interval=1h \
+  --prune \
+  --source=flux-monitoring \
+  --path="./monitoring/configs" \
+  --health-check-timeout=5m \
+```
+
+Deploy kube-prometheus-stack kustomization
+```shell
+flux create kustomization kube-prometheus-stack \
+  --interval=1h \
+  --prune \
+  --source=flux-monitoring \
+  --path="./monitoring/controllers/kube-prometheus-stack" \
+  --health-check-timeout=5m \
+```
+
+Deploy loki-stack kustomization
+```shell
+flux create kustomization loki-stack \
+  --interval=1h \
+  --prune \
+  --source=flux-monitoring \
+  --path="./monitoring/controllers/loki-stack" \
+  --health-check-timeout=5m \
+```
+
+### Verify instalation
+
 Wait for Flux to deploy the monitoring stack with:
 
 ```shell


### PR DESCRIPTION
Added CLI commands to bootstrap all monitoring resources in this repo. Solves problem in case don't want to bootstrap new cluster (you already have your cluster bootstrapped)

Looked deprecated docs https://v2-0.docs.fluxcd.io/flux/guides/monitoring/ and there is no equivalent cli commands to inside updated docs.

Let me know if you want to any questions/formatting is correct/would like to add more changes